### PR TITLE
Add conda-forge install instructions

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -21,6 +21,7 @@ navbar-links:
   Downloads:
     - Source Code: "https://github.com/prism-em/prismatic"
     - GUI Programs: "downloads-binaries"
+    - Conda-forge: "downloads-conda-forge"
     - Atomic Coordinates: "downloads-coordinates"
   Documentation:
     - Change Log: "docs-change-log"

--- a/downloads-binaries.md
+++ b/downloads-binaries.md
@@ -18,6 +18,38 @@ subtitle: Download binary installation files for Prismatic
 ### Mac OS X
 v1.2.1 installer coming soon.
 
+## Conda-forge packages
+
+GPU or CPU Prismatic binaries are packaged on [conda-forge](https://conda-forge.org) for Windows, MacOS and Linux. They can be installed easily in an Anaconda/Miniconda distribution using the conda package manager.
+
+To install all variants of prismatic, run from an Anaconda command prompt:
+
+~~~
+conda install prismatic -c conda-forge
+~~~
+If a CUDA compatible GPU is available, the GPU packages (linux only) will be selected by default and a cudatoolkit [compatible with your GPU](https://docs.nvidia.com/deploy/cuda-compatibility/index.html) (Kepler and above) will be installed automatically.
+To switch to CPU packages, see instructions below. If you don't want to install all variants, you can install them separately.
+
+To install prismatic CLI (`prismatic-cli` and `prismatic-double` for double precision):
+~~~
+conda install prismatic_cli -c conda-forge
+~~~
+
+To install prismatic GUI (`prismatic-gui`) with start menu shortcut on windows:
+~~~
+conda install prismatic_gui -c conda-forge
+~~~
+
+To install `pyprismatic`:
+~~~
+conda install pyprismatic -c conda-forge
+~~~
+
+To select CPU only packages, use the following syntax with any of the conda packages mentioned above:
+~~~
+conda install prismatic=*=cpu* -c conda-forge
+~~~
+
 ## Source Code
 [Current Build](http://www.github.com/prism-em/prismatic)
 

--- a/downloads-binaries.md
+++ b/downloads-binaries.md
@@ -20,15 +20,14 @@ v1.2.1 installer coming soon.
 
 ## Conda-forge packages
 
-GPU or CPU Prismatic binaries are packaged on [conda-forge](https://conda-forge.org) for Windows, MacOS and Linux. They can be installed easily in an Anaconda/Miniconda distribution using the conda package manager.
+GPU or CPU Prismatic binaries are packaged on [conda-forge](https://conda-forge.org) for Windows, MacOS and Linux. They can be installed easily in an Anaconda/Miniconda distribution using the [conda](https://docs.conda.io) or [mamba](https://github.com/mamba-org/mamba) package manager.
 
 To install all variants of prismatic, run from an Anaconda command prompt:
 
 ~~~
 conda install prismatic -c conda-forge
 ~~~
-If a CUDA compatible GPU is available, the GPU packages (linux only) will be selected by default and a cudatoolkit [compatible with your GPU](https://docs.nvidia.com/deploy/cuda-compatibility/index.html) (Kepler and above) will be installed automatically.
-To switch to CPU packages, see instructions below. If you don't want to install all variants, you can install them separately.
+If a CUDA compatible GPU is available, the GPU packages will be selected by default and a cudatoolkit [compatible with your GPU](https://docs.nvidia.com/deploy/cuda-compatibility/index.html) (Kepler and above) will be installed automatically. Otherwise, the CPU will be selected. To switch or explicitely select CPU packages, see instructions below. If you don't want to install all variants, you can install them separately.
 
 To install prismatic CLI (`prismatic-cli` and `prismatic-double` for double precision):
 ~~~

--- a/downloads-binaries.md
+++ b/downloads-binaries.md
@@ -18,36 +18,6 @@ subtitle: Download binary installation files for Prismatic
 ### Mac OS X
 v1.2.1 installer coming soon.
 
-## Conda-forge packages
-
-GPU or CPU Prismatic binaries are packaged on [conda-forge](https://conda-forge.org) for Windows, MacOS and Linux. They can be installed easily in an Anaconda/Miniconda distribution using the [conda](https://docs.conda.io) or [mamba](https://github.com/mamba-org/mamba) package manager.
-
-To install all variants of prismatic, run from an Anaconda command prompt:
-
-~~~
-conda install prismatic -c conda-forge
-~~~
-If a CUDA compatible GPU is available, the GPU packages will be selected by default and a cudatoolkit [compatible with your GPU](https://docs.nvidia.com/deploy/cuda-compatibility/index.html) (Kepler and above) will be installed automatically. Otherwise, the CPU will be selected. To switch or explicitely select CPU packages, see instructions below. If you don't want to install all variants, you can install them separately.
-
-To install prismatic CLI (`prismatic-cli` and `prismatic-double` for double precision):
-~~~
-conda install prismatic_cli -c conda-forge
-~~~
-
-To install prismatic GUI (`prismatic-gui`) with start menu shortcut on windows:
-~~~
-conda install prismatic_gui -c conda-forge
-~~~
-
-To install `pyprismatic`:
-~~~
-conda install pyprismatic -c conda-forge
-~~~
-
-To select CPU only packages, use the following syntax with any of the conda packages mentioned above:
-~~~
-conda install prismatic=*=cpu* -c conda-forge
-~~~
 
 ## Source Code
 [Current Build](http://www.github.com/prism-em/prismatic)

--- a/downloads-conda-forge.md
+++ b/downloads-conda-forge.md
@@ -1,0 +1,57 @@
+---
+title: Conda-forge
+subtitle: Install using conda-forge packages
+---
+
+
+GPU or CPU Prismatic binaries are packaged on [conda-forge](https://conda-forge.org) for Windows, MacOS and Linux. They can be installed easily in an Anaconda/Miniconda distribution using the [conda](https://docs.conda.io) or [mamba](https://github.com/mamba-org/mamba) package manager.
+
+The different variants of ``prismatic`` are available in 4 packages:
+- ``prismatic_cli`` to install the command line version
+- ``prismatic_gui`` to install the GUI version
+- ``pyprismatic`` to install the python binding
+- ``prismatic`` to install all 3 others packages
+
+Each of these packages are available with CPU or GPU capabilities (``prismatic`` doesn't support GPU on MacOS). To install one of the packages, the [Anaconda navigator](https://docs.anaconda.com/anaconda/navigator) can be used.
+Alternatively, one of the following commands can be ran from an Anaconda command prompt (on Windows) or a terminal (MacOS or Linux):
+
+~~~
+conda install prismatic -c conda-forge
+~~~
+If a CUDA compatible GPU is available, the GPU packages will be selected by default and a cudatoolkit [compatible with your GPU](https://docs.nvidia.com/deploy/cuda-compatibility/index.html) (Kepler and above) will be installed automatically. Otherwise, the CPU will be selected. To switch or explicitely select CPU packages, see instructions below.
+
+The ``prismatic`` package is a meta-package which install the packages of each variant. If you don't want to install all variants, you can install them separately. 
+
+To install prismatic CLI (``prismatic-cli`` and ``prismatic-double`` for double precision):
+~~~
+conda install prismatic_cli -c conda-forge
+~~~
+
+To install prismatic GUI (``prismatic-gui``) with start menu shortcut on windows:
+~~~
+conda install prismatic_gui -c conda-forge
+~~~
+
+To install ``pyprismatic``:
+~~~
+conda install pyprismatic -c conda-forge
+~~~
+
+## Select CPU or GPU build
+
+To select CPU only packages, use the following syntax with any of the conda packages mentioned above:
+~~~
+conda install prismatic=*=cpu* -c conda-forge
+~~~
+
+GPU packages are prioritise by default and it can happen that this priority is overwritten by another priority when conda or mamba resolves the dependencies tree. To pin to a specific computing backend (CPU or GPU), use the [pinning mechanism](https://docs.conda.io/projects/conda/en/latest/user-guide/tasks/manage-pkgs.html#preventing-packages-from-updating-pinning) of conda, either through:
+
+~~~
+conda config --env --add pinned_packages prismatic=*=gpu*
+~~~
+
+or by adding the package name and its pinning to the following to the ``env_path/conda-meta/pinned`` file:
+~~~
+prismatic=*=gpu*
+~~~
+


### PR DESCRIPTION
Now that the conda-forge packages are working fine, it would be good to document these on the website.

Closes #7.